### PR TITLE
V2.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 *.iml
 *.env
 config/config.*.yaml
+app/storage/*

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ __pycache__/
 *.iml
 *.env
 config/config.*.yaml
-app/storage/*
+storage/*

--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,7 @@ class APIConfig(BaseModel):
     workspaces: Dict[str, Workspace]
     domains: Dict[str, Domain]
     language_codes: Dict[str, str]
+    corrections_data_storage_path: str = "storage/corrections.txt"
 
 
 class APISettings(BaseSettings):

--- a/app/config.py
+++ b/app/config.py
@@ -20,7 +20,7 @@ class APIConfig(BaseModel):
     workspaces: Dict[str, Workspace]
     domains: Dict[str, Domain]
     language_codes: Dict[str, str]
-    corrections_data_storage_path: str = "storage/corrections.txt"
+    corrections_data_storage_path: str
 
 
 class APISettings(BaseSettings):

--- a/app/translation/v2_router.py
+++ b/app/translation/v2_router.py
@@ -57,7 +57,7 @@ async def correction(body: Correction, application: Optional[str] = Header(None,
     now = datetime.now()
     dt_string = now.strftime("%d/%m/%Y %H:%M:%S")
     filename = 'app/storage/corrections.txt'
-    output = f"---\ndate: {dt_string}\n\nrequest: {body.request}\n\noriginalTranslation: {body.response}\n\ncorrectedTranslation: {body.correction}\n---\n\n"
+    output = f"date: {dt_string}\n\nrequest: {body.request}\n\noriginalTranslation: {body.response}\n\ncorrectedTranslation: {body.correction}\n---\n\n"
     while True:
         try:
             with open(filename, 'a') as f:
@@ -67,3 +67,4 @@ async def correction(body: Correction, application: Optional[str] = Header(None,
         except IOError:
             # Failed to acquire lock, wait and try again
             time.sleep(.1)
+    return {"message": "success"}

--- a/app/translation/v2_schemas.py
+++ b/app/translation/v2_schemas.py
@@ -30,7 +30,8 @@ class Request(BaseModel):
     def __init__(self, **data: Any):
         super().__init__(**data)
 
-        length = len(self.text) if type(self.text) == str else sum([len(sent) for sent in self.text])
+        length = len(self.text) if type(self.text) == str else sum(
+            [len(sent) for sent in self.text])
         if length > api_settings.max_input_length:
             raise HTTPException(
                 status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
@@ -80,12 +81,12 @@ class Config(BaseModel):
 
 
 class Correction(BaseModel):
-    request: Union[str, List[str]] = Field(...,
-                                        description="An original translation request.",
-                                        example='{"text":"Aitäh!","tgt":"eng","src":"est"}')
-    response: Union[str, List[str]] = Field(...,
-                                        description="An original translation.",
-                                        example="Thank you!")
-    correction: Union[str, List[str]] = Field(...,
-                                        description="A user-corrected text.",
-                                        example="Thanks!")
+    request: str = Field(...,
+                         description="An original translation request.",
+                         example='{"text":"Aitäh!","tgt":"eng","src":"est"}')
+    response: str = Field(...,
+                          description="An original translation.",
+                          example="Thank you!")
+    correction: str = Field(...,
+                            description="A user-corrected text.",
+                            example="Thanks!")

--- a/app/translation/v2_schemas.py
+++ b/app/translation/v2_schemas.py
@@ -77,3 +77,15 @@ class Config(BaseModel):
                               description="[Deprecated] A boolean value whether using XML tags in text is supported.")
     domains: List[Domain] = Field(...,
                                   description="A list of supported domains and their configurations.")
+
+
+class Correction(BaseModel):
+    request: Union[str, List[str]] = Field(...,
+                                        description="An original translation request.",
+                                        example='{"text":"Aitäh!","tgt":"eng","src":"est"}')
+    response: Union[str, List[str]] = Field(...,
+                                        description="An original translation.",
+                                        example="Thank you!")
+    correction: Union[str, List[str]] = Field(...,
+                                        description="A user-corrected text.",
+                                        example="Thanks!")

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,3 +23,4 @@ domains:  # Domains of translation engines
 language_codes:  # A mapping of all language code formats to the default 3-letter format
     { "et": "est", "est": "est", "en": "eng", "eng": "eng", "de": "ger", "deu": "ger", "ger": "ger", "lt": "lit",
       "lit": "lit", "fi": "fin", "fin": "fin", "lv": "lav", "lav": "lav", "ru": "rus", "rus": "rus" }
+corrections_data_storage_path: "storage/corrections.txt" # A path to the file with user-corrected translations data


### PR DESCRIPTION
Frontend is sending all data as strings, so POST `/v2/correction ` accepts three keys - `request` which contains the original translation request data; `response` - the original translation text; `correction` - the user-corrected translation.
A path to the file where all user-corrections are stored should be defined in `config/confg.yaml` in the parameter `corrections_data_storage_path`.

Example of saved data:
```
date: 27/02/2023 15:21:40

request: {"text":"Maailma","tgt":"eng","src":"est"}

originalTranslation: the World

correctedTranslation: of the World
---

date: 27/02/2023 15:25:40

request: {"text":"Aitäh!","tgt":"eng","src":"est"}

originalTranslation: Thank you!

correctedTranslation: Thanks!
---
```